### PR TITLE
Suppress Error About Variable Length Arrays Being a Clang Extension

### DIFF
--- a/build-chdman.sh
+++ b/build-chdman.sh
@@ -181,7 +181,7 @@ g++    -MMD -MP -MP -DNDEBUG -DCRLF=2 -DLSB_FIRST -DFLAC__NO_DLL -DPUGIXML_HEADE
 echo "Building chdman.o"
 
 mkdir -p obj/Release/src/tools
-g++    -MMD -MP -MP -DNDEBUG -DCRLF=2 -DLSB_FIRST -DFLAC__NO_DLL -DPUGIXML_HEADER_ONLY -DLUA_COMPAT_ALL -DLUA_COMPAT_5_1 -DLUA_COMPAT_5_2 -DPTR64=1 -I"src/osd" -I"src/lib/util" -I"3rdparty" -I"3rdparty/libflac/include"  -g -std=c++17 -pipe -Werror -O3 -fno-strict-aliasing -Wno-unknown-pragmas -Wall -Wcast-align -Wformat-security -Wundef -Wwrite-strings -Wno-conversion -Wno-sign-compare -Wno-error=deprecated-declarations -Wno-unused-result -Wno-array-bounds -Wno-error=attributes -Wno-string-concatenation -Wno-shift-overflow -Wno-return-stack-address -Wno-cast-align -std=c++17 -Woverloaded-virtual -Wimplicit-fallthrough -Wno-class-varargs  -o "obj/Release/src/tools/chdman.o" -c "src/tools/chdman.cpp"
+g++    -MMD -MP -MP -DNDEBUG -DCRLF=2 -DLSB_FIRST -DFLAC__NO_DLL -DPUGIXML_HEADER_ONLY -DLUA_COMPAT_ALL -DLUA_COMPAT_5_1 -DLUA_COMPAT_5_2 -DPTR64=1 -I"src/osd" -I"src/lib/util" -I"3rdparty" -I"3rdparty/libflac/include"  -g -std=c++17 -pipe -Werror -Wno-error=vla-cxx-extension -O3 -fno-strict-aliasing -Wno-unknown-pragmas -Wall -Wcast-align -Wformat-security -Wundef -Wwrite-strings -Wno-conversion -Wno-sign-compare -Wno-error=deprecated-declarations -Wno-unused-result -Wno-array-bounds -Wno-error=attributes -Wno-string-concatenation -Wno-shift-overflow -Wno-return-stack-address -Wno-cast-align -std=c++17 -Woverloaded-virtual -Wimplicit-fallthrough -Wno-class-varargs  -o "obj/Release/src/tools/chdman.o" -c "src/tools/chdman.cpp"
 
 echo "Creating executable chdman"
 


### PR DESCRIPTION
Hello.
I have a [bash script](https://github.com/Thysbelon/Convert2VibFormat) that I wrote a few years ago that, on Android Termux, relies on your [chdman installation script](https://www.reddit.com/r/EmulationOnAndroid/comments/riqu81/guidedefinitiveconvert_your_games_with_chdman_on/) to function. Thank you for writing that chdman installation script.
In the years since I wrote my script, something about the compiler changed, and now your script fails to compile chdman.o and give the error "variable length arrays in C++ are a Clang extension".
I suppressed the error, and it seems to fix the issue. Chdman compiles and successfully compresses disc images (though I didn't test it rigorously).